### PR TITLE
Fix install bazel in CI

### DIFF
--- a/.github/workflows/ubuntu_basic.yml
+++ b/.github/workflows/ubuntu_basic.yml
@@ -19,11 +19,17 @@ jobs:
       run:  |
             apt-get update
             apt-get install -yq wget gcc g++ openjdk-8-jdk python3.7 zlib1g-dev zip
+            apt-get install -yq pip
             wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb" -O bazel_5.1.0-linux-x86_64.deb
             dpkg -i bazel_5.1.0-linux-x86_64.deb
 
     - name: Install Ray
-      run: pip install ray==1.11.0
+      run:  |
+            python3 -m pip install virtualenv
+            python3 -m virtualenv -p python3 py3
+            . py3/bin/activate
+            pip install pytest
+            pip install ray==1.11.0
 
     - name: Build Pygloo
       run: python setup.py install

--- a/.github/workflows/ubuntu_basic.yml
+++ b/.github/workflows/ubuntu_basic.yml
@@ -25,8 +25,12 @@ jobs:
 
     - name: Install Ray
       run:  |
+            set -e
+            set -x
             python3 -m pip install virtualenv
             python3 -m virtualenv -p python3 py3
+            source py3/bin/activate
+            which python
             pip install pytest
             pip install ray==1.11.0
 

--- a/.github/workflows/ubuntu_basic.yml
+++ b/.github/workflows/ubuntu_basic.yml
@@ -27,7 +27,6 @@ jobs:
       run:  |
             python3 -m pip install virtualenv
             python3 -m virtualenv -p python3 py3
-            source py3/bin/activate
             pip install pytest
             pip install ray==1.11.0
 

--- a/.github/workflows/ubuntu_basic.yml
+++ b/.github/workflows/ubuntu_basic.yml
@@ -19,7 +19,8 @@ jobs:
       run:  |
             apt-get update
             apt-get install -yq wget gcc g++ openjdk-8-jdk python3.7 zlib1g-dev zip
-            sh scripts/install-bazel.sh
+            wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb" -O bazel_5.1.0-linux-x86_64.deb
+            dpkg -i bazel_5.1.0-linux-x86_64.deb
 
     - name: Install Ray
       run: pip install ray==1.11.0
@@ -29,3 +30,4 @@ jobs:
 
     - name: Test
       run: pytest -v ./tests
+

--- a/.github/workflows/ubuntu_basic.yml
+++ b/.github/workflows/ubuntu_basic.yml
@@ -27,7 +27,7 @@ jobs:
       run:  |
             python3 -m pip install virtualenv
             python3 -m virtualenv -p python3 py3
-            . py3/bin/activate
+            source py3/bin/activate
             pip install pytest
             pip install ray==1.11.0
 


### PR DESCRIPTION
We don't have `scripts/install-bazel.sh` script file, let us download bazel and install it.