### PR TITLE
ci: restrict GITHUB_TOKEN to read-only on ubuntu-basic

### DIFF
--- a/.github/workflows/ubuntu_basic.yml
+++ b/.github/workflows/ubuntu_basic.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   run-unit-tests:
     timeout-minutes: 60


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to the ubuntu-basic test workflow.

The workflow checks out source, installs bazel and Python dependencies, builds and runs tests inside a Ubuntu 20.04 container. None of these need write access to the repository. Scoping the GITHUB_TOKEN to read-only follows least-privilege guidance.